### PR TITLE
Configurable max_results

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -11,12 +11,12 @@ exports.sourceNodes = async ({
     createNode
   } = actions;
   const {
-    folders
+    folders, max_results
   } = configOptions;
   const queryParams = {
     tags: true,
     type: 'upload',
-    max_results: `24`,
+    max_results: max_results || `24`,
     resource_type: 'image'
   };
   delete configOptions.plugins;


### PR DESCRIPTION
allow to specifiy in plugin config, to return more than the (hard-coded) default of 24.

Note: Cloudinary uses 10 as a default, you may want to consider changing to that default value too?  (see https://cloudinary.com/documentation/admin_api#list_resources)